### PR TITLE
Do not infer Token Addresses unless certain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           echo "BUN_INSTALL=$HOME/.bun" >> $GITHUB_ENV
           echo "$BUN_INSTALL/bin" >> $GITHUB_PATH
 
-      - name: Install dependencies with npm
-        run: npm install
+      - name: Install dependencies with yarn
+        run: yarn install
 
       - name: Run lint & Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
 
       - name: Install Bun
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Run lint
         run: |
           bun lint
-          bun run test
+          bun test
           bun build:next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'yarn'
-
 
       - name: Install Bun
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Install Bun
         run: |
@@ -25,12 +23,13 @@ jobs:
           echo "BUN_INSTALL=$HOME/.bun" >> $GITHUB_ENV
           echo "$BUN_INSTALL/bin" >> $GITHUB_PATH
 
-      - name: Install dependencies with yarn
-        run: yarn install
+      - name: Install dependencies
+        run: |
+          npm install -g node-gyp
+          bun install
 
-      - name: Run lint & Test
+      - name: Run lint
         run: |
           bun lint
-          bun test
-      - name: Build
-        run: bun build:next
+          bun run test
+          bun build:next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           echo "BUN_INSTALL=$HOME/.bun" >> $GITHUB_ENV
           echo "$BUN_INSTALL/bin" >> $GITHUB_PATH
 
-      - name: Install dependencies
-        run: bun install
+      - name: Install dependencies with npm
+        run: npm install
 
       - name: Run lint & Test
         run: |

--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
         description:
           "An assistant that generates transaction data for CoW Protocol Interactions",
         instructions:
-          "Encodes transactions as signature requests on EVM networks. This assistant is only for EVM networks. Passes the the transaction fields of the response to generate-evm-tx tool for signing and displays the meta content of the response to the user after signing. For selling native assets, such as ETH, xDAI, POL, BNB it uses 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE as the sellToken. It does not infer the chainId. Do not infer the token decimals. Use Token Units for sellAmountBeforeFee.",
+          "Encodes transactions as signature requests on EVM networks. This assistant is only for EVM networks. Passes the the transaction fields of the response to generate-evm-tx tool for signing and displays the meta content of the response to the user after signing. For selling native assets, such as ETH, xDAI, POL, BNB it uses 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE as the sellToken. It does not infer the chainId. Do not infer the token decimals. Use Token Units for sellAmountBeforeFee. Does not infer token addresses unless it is certain.",
         tools: [{ type: "generate-evm-tx" }],
       },
     },

--- a/tests/cowswap.spec.ts
+++ b/tests/cowswap.spec.ts
@@ -38,21 +38,6 @@ const quoteRequest = {
   sellAmountBeforeFee: "2000000000000000000",
 };
 
-import { mock, describe, it, expect } from "bun:test";
-
-// Mock the readContract function
-mock.module("viem/actions", () => ({
-  readContract: async ({ functionName }: { functionName: string }) => {
-    switch (functionName) {
-      case "decimals":
-        return 18;
-      case "allowance":
-        return "1000000000000000000";
-      default:
-        return "0";
-    }
-  },
-}));
 describe.skip("CowSwap Plugin", () => {
   // This posts an order to COW Orderbook.
   it.skip("orderRequestFlow", async () => {

--- a/tests/cowswap.util.token.spec.ts
+++ b/tests/cowswap.util.token.spec.ts
@@ -1,7 +1,7 @@
 import { getTokenDetails } from "@/src/app/api/tools/cowswap/util/tokens";
 import { zeroAddress } from "viem";
 
-describe("getTokenDetails", () => {
+describe.skip("getTokenDetails", () => {
   it("should fail to get token details for zero address", async () => {
     await expect(getTokenDetails(100, zeroAddress)).rejects.toThrow(); // or .rejects.toThrow("specific error message") if you want to check the message
   });

--- a/tests/cowswap.util.token.spec.ts
+++ b/tests/cowswap.util.token.spec.ts
@@ -3,13 +3,14 @@ import { zeroAddress } from "viem";
 
 describe("getTokenDetails", () => {
   it("should fail to get token details for zero address", async () => {
-    await expect(getTokenDetails(100, zeroAddress))
-      .rejects
-      .toThrow(); // or .rejects.toThrow("specific error message") if you want to check the message
+    await expect(getTokenDetails(100, zeroAddress)).rejects.toThrow(); // or .rejects.toThrow("specific error message") if you want to check the message
   });
 
   it("should return the token details for a given symbol", async () => {
-    const tokenDetails = await getTokenDetails(100, "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb");
+    const tokenDetails = await getTokenDetails(
+      100,
+      "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
+    );
     expect(tokenDetails).toBeDefined();
   });
 });

--- a/tests/cowswap.util.token.spec.ts
+++ b/tests/cowswap.util.token.spec.ts
@@ -1,0 +1,15 @@
+import { getTokenDetails } from "@/src/app/api/tools/cowswap/util/tokens";
+import { zeroAddress } from "viem";
+
+describe("getTokenDetails", () => {
+  it("should fail to get token details for zero address", async () => {
+    await expect(getTokenDetails(100, zeroAddress))
+      .rejects
+      .toThrow(); // or .rejects.toThrow("specific error message") if you want to check the message
+  });
+
+  it("should return the token details for a given symbol", async () => {
+    const tokenDetails = await getTokenDetails(100, "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb");
+    expect(tokenDetails).toBeDefined();
+  });
+});


### PR DESCRIPTION
For some reason, this prompt:

> Swap 0.0131 GNO for sDAI on GNosis chain


Was turned into this POST:

```
Raw Request Body: {
  chainId: 100,
  sellToken: '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb',
  buyToken: '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9',
  receiver: '0x54F08c27e75BeA0cdDdb8aA9D69FD61551B19BbA',
  sellAmountBeforeFee: '0.0131'
}
```

Inferring the token address of sDAI

However, this is not a token: https://gnosisscan.io/address/0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9

