### PR TITLE
Support Native ETH Sell Orders

### DIFF
--- a/src/app/api/tools/cowswap/orderFlow.ts
+++ b/src/app/api/tools/cowswap/orderFlow.ts
@@ -31,6 +31,7 @@ export async function orderRequestFlow({
     metaTransactions.push(
       wrapMetaTransaction(chainId, BigInt(quoteRequest.sellAmountBeforeFee)),
     );
+    quoteRequest.sellToken = getWethAddress(chainId);
   }
 
   const orderbook = new OrderBookApi({ chainId });
@@ -83,3 +84,7 @@ export async function orderRequestFlow({
     meta: { orderUrl: `explorer.cow.fi/orders/${orderUid}` },
   };
 }
+function getWethAddress(chainId: number): string {
+  throw new Error("Function not implemented.");
+}
+

--- a/src/app/api/tools/cowswap/orderFlow.ts
+++ b/src/app/api/tools/cowswap/orderFlow.ts
@@ -10,7 +10,7 @@ import {
 } from "./util/protocol";
 import { OrderBookApi } from "@cowprotocol/cow-sdk";
 import { signRequestFor } from "../util";
-import { wrapMetaTransaction } from "../weth/utils";
+import { getWethAddress, wrapMetaTransaction } from "../weth/utils";
 
 const slippageBps = parseInt(process.env.SLIPPAGE_BPS || "100");
 
@@ -84,7 +84,3 @@ export async function orderRequestFlow({
     meta: { orderUrl: `explorer.cow.fi/orders/${orderUid}` },
   };
 }
-function getWethAddress(chainId: number): string {
-  throw new Error("Function not implemented.");
-}
-

--- a/src/app/api/tools/cowswap/orderFlow.ts
+++ b/src/app/api/tools/cowswap/orderFlow.ts
@@ -1,4 +1,4 @@
-import { SignRequestData } from "near-safe";
+import { MetaTransaction, SignRequestData } from "near-safe";
 import {
   applySlippage,
   buildAndPostAppData,
@@ -10,6 +10,7 @@ import {
 } from "./util/protocol";
 import { OrderBookApi } from "@cowprotocol/cow-sdk";
 import { signRequestFor } from "../util";
+import { wrapMetaTransaction } from "../weth/utils";
 
 const slippageBps = parseInt(process.env.SLIPPAGE_BPS || "100");
 
@@ -20,10 +21,15 @@ export async function orderRequestFlow({
   transaction: SignRequestData;
   meta: { orderUrl: string };
 }> {
+  if (
+    !(quoteRequest.kind === "sell" && "sellAmountBeforeFee" in quoteRequest)
+  ) {
+    throw new Error(`Quote Request is not a sell order`);
+  }
+  const metaTransactions: MetaTransaction[] = [];
   if (isNativeAsset(quoteRequest.sellToken)) {
-    // TODO: Integrate EthFlow
-    throw new Error(
-      `This agent does not currently support Native Asset Sell Orders.`,
+    metaTransactions.push(
+      wrapMetaTransaction(chainId, BigInt(quoteRequest.sellAmountBeforeFee)),
     );
   }
 
@@ -61,12 +67,15 @@ export async function orderRequestFlow({
     chainId,
     sellAmount: quoteResponse.quote.sellAmount,
   });
+  if (approvalTx) {
+    metaTransactions.push(approvalTx);
+  }
 
   return {
     transaction: signRequestFor({
       chainId,
       metaTransactions: [
-        ...(approvalTx ? [approvalTx] : []),
+        ...(metaTransactions.length > 0 ? metaTransactions : []),
         // Encode setPresignature (this is onchain confirmation of order signature.)
         setPresignatureTx(orderUid),
       ],

--- a/src/app/api/tools/weth/utils.ts
+++ b/src/app/api/tools/weth/utils.ts
@@ -1,13 +1,12 @@
-import { Network } from "near-safe";
-import { Address, isAddress } from "viem";
+import { MetaTransaction, Network, SignRequestData } from "near-safe";
+import { Address, getAddress, parseEther, toHex } from "viem";
+import { signRequestFor } from "../util";
 
-interface ValidInput {
+export function validateWethInput(params: URLSearchParams): {
   chainId: number;
-  amount: number;
+  amount: bigint;
   wethAddress: Address;
-}
-
-export function validateWethInput(params: URLSearchParams): ValidInput {
+} {
   const chainIdStr = params.get("chainId");
   const amountStr = params.get("amount");
 
@@ -31,13 +30,42 @@ export function validateWethInput(params: URLSearchParams): ValidInput {
     throw new Error("Invalid amount, must be a positive float");
   }
 
+  return {
+    chainId,
+    amount: parseEther(amount.toString()),
+    wethAddress: getWethAddress(chainId),
+  };
+}
+
+export function wrapSignRequest(
+  chainId: number,
+  amount: bigint,
+): SignRequestData {
+  return signRequestFor({
+    chainId,
+    metaTransactions: [wrapMetaTransaction(chainId, amount)],
+  });
+}
+
+export const wrapMetaTransaction = (
+  chainId: number,
+  amount: bigint,
+): MetaTransaction => {
+  return {
+    to: getWethAddress(chainId),
+    value: toHex(amount),
+    // methodId for weth.deposit
+    data: "0xd0e30db0",
+  };
+};
+
+function getWethAddress(chainId: number): Address {
   const network = Network.fromChainId(chainId);
   const wethAddress = network.nativeCurrency.wrappedAddress;
-  if (!wethAddress || !isAddress(wethAddress, { strict: false })) {
+  if (!wethAddress) {
     throw new Error(
       `Couldn't find wrapped address for Network ${network.name} (chainId=${chainId})`,
     );
   }
-
-  return { chainId, amount, wethAddress };
+  return getAddress(wethAddress);
 }

--- a/src/app/api/tools/weth/utils.ts
+++ b/src/app/api/tools/weth/utils.ts
@@ -59,7 +59,7 @@ export const wrapMetaTransaction = (
   };
 };
 
-function getWethAddress(chainId: number): Address {
+export function getWethAddress(chainId: number): Address {
   const network = Network.fromChainId(chainId);
   const wethAddress = network.nativeCurrency.wrappedAddress;
   if (!wethAddress) {

--- a/src/app/api/tools/weth/wrap/route.ts
+++ b/src/app/api/tools/weth/wrap/route.ts
@@ -1,24 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { parseEther, toHex } from "viem";
 import { validateWethInput } from "../utils";
-import { signRequestFor } from "../../util";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const search = req.nextUrl.searchParams;
   console.log("wrap/", search);
   try {
-    const { chainId, amount, wethAddress } = validateWethInput(search);
-    const signRequest = signRequestFor({
-      chainId,
-      metaTransactions: [
-        {
-          to: wethAddress,
-          value: toHex(parseEther(amount.toString())),
-          // methodId for weth.deposit
-          data: "0xd0e30db0",
-        },
-      ],
-    });
+    const signRequest = validateWethInput(search);
     return NextResponse.json(signRequest, { status: 200 });
   } catch (error: unknown) {
     const message =


### PR DESCRIPTION
1. Detect Native Asset sell order.
2. prepend a wrap eth tx for the sell amount.
3. update quote sell token to WETH.
4. Continue.