### PR TITLE
Use Static Chains List

### DIFF
--- a/src/app/api/tools/balance.ts
+++ b/src/app/api/tools/balance.ts
@@ -9,7 +9,8 @@ export async function getBalances(
   try {
     const zerion = new ZerionAPI(zerionKey);
     const balances = await zerion.ui.getUserBalances(address, {
-      options: { hideDust: 0.05 },
+      useStatic: true,
+      options: { hideDust: 0.01 },
     });
     return zerionToTokenBalances(balances.tokens);
   } catch (error) {


### PR DESCRIPTION
We are currently hitting an error with zerion fetch /chains/. While we investigate we will `useStatic` chains.

```
Error fetching Zerion balances: 30 |             ...(this.env ? { "X-Env": this.env } : {}),
31 |         };
32 |         const url = `${config_1.ZERION_CONFIG.BASE_URL}${endpoint}`;
33 |         const response = await fetch(url, { headers });
34 |         if (!response.ok) {
35 |             throw new Error(`Failed to fetch ${endpoint}: ${response.statusText}`);
                       ^
error: Failed to fetch /chains/: Internal Server Error
      at fetchFromZerion (/Users/bh2smith/Projects/bh2smith/agents/cow/node_modules/zerion-sdk/dist/cjs/src/services/zerion.js:35:19)

[]
```