### PR TITLE
Fix: Insufficient Balance Message

### DIFF
--- a/src/app/api/tools/balance.ts
+++ b/src/app/api/tools/balance.ts
@@ -50,8 +50,9 @@ export async function assertSufficientBalance(
       balance !== null
         ? formatUnits(balance, token?.decimals ?? 18)
         : "unknown";
+    const need = formatUnits(amount, token?.decimals ?? 18);
     throw new Error(
-      `Insufficient SellToken Balance: Have ${have} - Need ${amount}`,
+      `Insufficient SellToken Balance: Have ${have} < Need ${need}`,
     );
   }
 }


### PR DESCRIPTION
Previously:

```
Insufficient SellToken Balance: Have 0.002882888647226556 - Need 230000000000000000
```

Now:

```
Insufficient SellToken Balance: Have 0.002882888647226556 - Need 0.0023
```