### PR TITLE
User Configurable Slippage

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -76,6 +76,15 @@ This assistant follows these specifications with zero deviation to ensure secure
             { $ref: "#/components/parameters/buyToken" },
             { $ref: "#/components/parameters/receiver" },
             {
+              name: "slippageBps",
+              in: "query",
+              schema: {
+                type: "number",
+              },
+              description:
+                "The slippage tolerance for the quote, represented as a percentage in basis points (BPS).",
+            },
+            {
               name: "amount",
               in: "query",
               required: true,

--- a/src/app/api/tools/quote/route.ts
+++ b/src/app/api/tools/quote/route.ts
@@ -17,9 +17,6 @@ import type { MetaTransaction, SignRequest, SwapFTData } from "@bitte-ai/types";
 import type { OrderParameters, OrderQuoteResponse } from "@cowprotocol/cow-sdk";
 import type { NextRequest } from "next/server";
 
-// TODO: Allow User to set Slippage.
-const slippageBps = Number.parseInt(process.env.SLIPPAGE_BPS || "100");
-
 export async function POST(req: NextRequest): Promise<NextResponse> {
   console.log("quote/", req.url);
   return handleRequest(req, logic, (result) => NextResponse.json(result));
@@ -33,12 +30,13 @@ async function logic(req: NextRequest): Promise<{
   const requestBody = await req.json();
   // Early Extract ChainId
   const client = getClient(requestBody.chainId, getAlchemyKey());
-  const { chainId, quoteRequest, tokenData } = await basicParseQuote(
-    client,
-    requestBody,
-    // Temporarily disable tokenMap Caching
-    await loadTokenMap(COW_SUPPORTED_CHAINS),
-  );
+  const { chainId, quoteRequest, tokenData, slippageBps } =
+    await basicParseQuote(
+      client,
+      requestBody,
+      // Temporarily disable tokenMap Caching
+      await loadTokenMap(COW_SUPPORTED_CHAINS),
+    );
   console.log("Parsed Quote Request", quoteRequest);
   const notes: string[] = [];
   const orderBookApi = new OrderBookApi({ chainId });

--- a/src/lib/protocol/quote.ts
+++ b/src/lib/protocol/quote.ts
@@ -14,6 +14,8 @@ import type { MetaTransaction } from "@bitte-ai/types";
 import type { OrderParameters, OrderQuoteSide } from "@cowprotocol/cow-sdk";
 import type { Address } from "viem";
 
+const slippageDefault = Number.parseInt(process.env.SLIPPAGE_BPS || "100");
+
 export async function basicParseQuote(
   client: EthRpc,
   requestBody: QuoteRequestBody,
@@ -28,6 +30,7 @@ export async function basicParseQuote(
     orderKind,
     evmAddress: sender,
     receiver,
+    slippageBps,
   } = requestBody;
   console.log("Quote Request Body", requestBody);
 
@@ -61,6 +64,7 @@ export async function basicParseQuote(
       buy: buyTokenData,
       sell: sellTokenData,
     },
+    slippageBps: slippageBps ?? slippageDefault,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,11 +31,13 @@ export type QuoteRequestBody = {
   orderKind: string;
   evmAddress: `0x${string}`;
   receiver: string;
+  slippageBps?: number;
 };
 export interface ParsedQuoteRequest {
   quoteRequest: OrderQuoteRequest;
   chainId: number;
   tokenData: { buy: TokenInfo; sell: TokenInfo };
+  slippageBps: number;
 }
 
 export type EthRpc = PublicClient<Transport, Chain>;


### PR DESCRIPTION
Users may now specify slippage as part of their request. It is not required - and defaults to 1% (i.e. 100 BPS) if not provided.