### PR TITLE
Feature: Order Status

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -326,15 +326,7 @@ This assistant follows these specifications with zero deviation to ensure secure
           `,
           parameters: [
             { $ref: "#/components/parameters/chainId" },
-            {
-              in: "query",
-              name: "orderUid",
-              required: true,
-              schema: {
-                type: "string",
-              },
-              description: "The order UID to cancel.",
-            },
+            { $ref: "#/components/parameters/orderUid" },
             {
               in: "query",
               name: "signature",
@@ -377,10 +369,90 @@ This assistant follows these specifications with zero deviation to ensure secure
           },
         },
       },
+      "/api/tools/status": {
+        get: {
+          tags: ["status"],
+          operationId: "orderStatus",
+          summary: "Retrieves the status of an order by id.",
+          description: `This tool utilizes the cow orderbook api endpoint for status (https://api.cow.fi/docs/#/default/get_api_v1_orders__UID__status)`,
+          parameters: [
+            { $ref: "#/components/parameters/chainId" },
+            { $ref: "#/components/parameters/orderUid" },
+          ],
+          responses: {
+            "200": {
+              description:
+                "The order status with a list of solvers that proposed solutions (if applicable).",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      order: {
+                        type: "string",
+                        enum: [
+                          "presignaturePending",
+                          "open",
+                          "fulfilled",
+                          "cancelled",
+                          "expired",
+                        ],
+                      },
+                      competition: {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            enum: [
+                              "open",
+                              "scheduled",
+                              "active",
+                              "solved",
+                              "executing",
+                              "traded",
+                              "cancelled",
+                            ],
+                          },
+                          value: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                solver: { type: "string" },
+                                executedAmounts: {
+                                  $ref: "#/components/schemas/ExecutedAmounts",
+                                },
+                              },
+                              required: ["solver"],
+                            },
+                          },
+                        },
+                        required: ["type"],
+                      },
+                    },
+                    required: ["order", "competition"],
+                  },
+                },
+              },
+            },
+            "404": { description: "Not Found" },
+            "500": { description: "Internal Server Error." },
+          },
+        },
+      },
     },
     components: {
       parameters: {
         chainId: chainIdParam,
+        orderUid: {
+          in: "query",
+          name: "orderUid",
+          required: true,
+          schema: {
+            type: "string",
+          },
+          description: "The unique identifier of a CoW Protocol order.",
+        },
         amount: amountParam,
         address: addressParam,
         evmAddress: {
@@ -996,6 +1068,24 @@ This assistant follows these specifications with zero deviation to ensure secure
               },
             },
           ],
+        },
+        ExecutedAmounts: {
+          type: "object",
+          properties: {
+            sell: {
+              $ref: "#/components/schemas/BigUint",
+            },
+            buy: {
+              $ref: "#/components/schemas/BigUint",
+            },
+          },
+          required: ["sell", "buy"],
+        },
+        BigUint: {
+          type: "string",
+          pattern: "^[0-9]+$",
+          description:
+            "Arbitrary-precision unsigned integer encoded as a base-10 string.",
         },
       },
     },

--- a/src/app/api/tools/status/logic.ts
+++ b/src/app/api/tools/status/logic.ts
@@ -1,0 +1,33 @@
+import { OrderBookApi } from "@cowprotocol/cow-sdk";
+
+import { withCowErrorHandling } from "@/src/lib/error";
+import { OrderStatusSchema, parseRequest } from "@/src/lib/schema";
+
+import type { OrderStatusInput } from "@/src/lib/schema";
+import type { CompetitionOrderStatus, OrderStatus } from "@cowprotocol/cow-sdk";
+import type { NextRequest } from "next/server";
+
+type StatusResponse = {
+  order: OrderStatus;
+  competition: CompetitionOrderStatus;
+};
+
+export async function logic(req: NextRequest): Promise<StatusResponse> {
+  const data = parseRequest(req, OrderStatusSchema);
+  return handleOrderStatusRequest(data);
+}
+
+export async function handleOrderStatusRequest(
+  input: OrderStatusInput,
+): Promise<StatusResponse> {
+  const orderbook = new OrderBookApi({ chainId: input.chainId });
+  // Get order: will throw with not found if order doesn't exist.
+  const order = await withCowErrorHandling(
+    orderbook.getOrderMultiEnv(input.orderUid),
+  );
+  // Since the above didn't throw =>
+  // can retrive competition status because we know the order exists.
+  const competition = await orderbook.getOrderCompetitionStatus(input.orderUid);
+  console.log("Competition Status", competition);
+  return { order: order.status, competition };
+}

--- a/src/app/api/tools/status/logic.ts
+++ b/src/app/api/tools/status/logic.ts
@@ -28,6 +28,6 @@ export async function handleOrderStatusRequest(
   // Since the above didn't throw =>
   // can retrive competition status because we know the order exists.
   const competition = await orderbook.getOrderCompetitionStatus(input.orderUid);
-  console.log("Competition Status", competition);
+  console.log("Found competition", competition);
   return { order: order.status, competition };
 }

--- a/src/app/api/tools/status/route.ts
+++ b/src/app/api/tools/status/route.ts
@@ -1,0 +1,11 @@
+import { handleRequest } from "@bitte-ai/agent-sdk";
+import { NextResponse } from "next/server";
+
+import { logic } from "./logic";
+
+import type { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  console.log("status/", req.url);
+  return handleRequest(req, logic, (result) => NextResponse.json(result));
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
 import type { NextRequest } from "next/server";
-import type { ZodTypeAny } from "zod";
+import type { ZodTypeAny } from "zod"; // TODO: says deprecated, but I can't see where or an alternative.
 
 export function parseRequest<T extends ZodTypeAny>(
   req: NextRequest,
@@ -20,18 +20,29 @@ export const signatureSchema = z
       "Signature must be a 65-byte (130 hex char) string starting with 0x",
   });
 
+export const orderUidSchema = z
+  .string()
+  .startsWith("0x")
+  .refine((id) => /^0x[0-9a-fA-F]{112}$/.test(id), {
+    message:
+      "OrderUid must be a 56-byte (112 hex char) string starting with 0x",
+  });
+
+export const chainIdSchema = z.coerce.number().int().positive({
+  message: "chainId must be a positive integer",
+});
+
 export const CancelOrderSchema = z.object({
-  chainId: z.coerce.number().int().positive({
-    message: "chainId must be a positive integer",
-  }),
-  orderUid: z
-    .string()
-    .startsWith("0x")
-    .refine((sig) => /^0x[0-9a-fA-F]{112}$/.test(sig), {
-      message:
-        "Signature must be a 56-byte (112 hex char) string starting with 0x",
-    }),
+  chainId: chainIdSchema,
+  orderUid: orderUidSchema,
   signature: signatureSchema.optional(),
 });
 
 export type CancelOrderInput = z.infer<typeof CancelOrderSchema>;
+
+export const OrderStatusSchema = z.object({
+  chainId: chainIdSchema,
+  orderUid: orderUidSchema,
+});
+
+export type OrderStatusInput = z.infer<typeof OrderStatusSchema>;

--- a/tests/status.spec.ts
+++ b/tests/status.spec.ts
@@ -1,0 +1,83 @@
+import { handleOrderStatusRequest } from "@/src/app/api/tools/status/logic";
+
+const nonExistentOrder =
+  "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const filledOrder =
+  "0xf944f0de097e6c3724ebbd4e18881df348ca6e8fc388b322e76b5aa139a819fcb00b4c1e371dee4f6f32072641430656d3f7c0646884e57b";
+const cancelledOrder =
+  "0xe46e8c19e371fbcc3797898796292cba68eb8cc27ca32d35305e0087d8d9c46ab00b4c1e371dee4f6f32072641430656d3f7c0646899c71e";
+const expiredOrder =
+  "0xe78df3254b7b8162f4b025a41f8fa67573575857b0e8c59688f9888342f074f6b00b4c1e371dee4f6f32072641430656d3f7c0646899c054";
+
+// Uncomment to test (makes requests to CoW Orderbook API)
+describe.skip("Order Status Route", () => {
+  it("Throws on not Found", async () => {
+    await expect(
+      handleOrderStatusRequest({
+        chainId: 1,
+        orderUid: nonExistentOrder,
+      }),
+    ).rejects.toThrow("NotFound: Order was not found");
+  });
+  it("Retrieves Filled/Traded Order Status", async () => {
+    const res = await handleOrderStatusRequest({
+      chainId: 1,
+      orderUid: filledOrder,
+    });
+    expect(res).toStrictEqual({
+      order: "fulfilled",
+      competition: {
+        type: "traded",
+        value: [
+          {
+            solver: "quasilabs",
+            executedAmounts: {
+              sell: "25464867331308488",
+              buy: "95075261",
+            },
+          },
+          {
+            solver: "quasilabs",
+            executedAmounts: null,
+          },
+          {
+            solver: "quasilabs",
+            executedAmounts: null,
+          },
+          {
+            solver: "barter",
+            executedAmounts: {
+              sell: "25464867331308488",
+              buy: "95155864",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("Retrieves cancelled Order Status", async () => {
+    const res = await handleOrderStatusRequest({
+      chainId: 1,
+      orderUid: cancelledOrder,
+    });
+    expect(res).toStrictEqual({
+      order: "cancelled",
+      competition: {
+        type: "cancelled",
+      },
+    });
+  });
+  it("Retrieves expired Order Status", async () => {
+    const res = await handleOrderStatusRequest({
+      chainId: 1,
+      orderUid: expiredOrder,
+    });
+    expect(res).toStrictEqual({
+      order: "expired",
+      competition: {
+        type: "active",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Users can now request order status by orderUid. The chat should be smart enough for users to just ask for their order status if they have just placed one (since its in the message history/context).


**Commits**
- 6745e98 - Functional Status Route without Tests
- 607bad6 - Add Tests


Closes #104 
