### PR TITLE
Optional User Specified Order Validity on Quote

### DIFF
--- a/src/app/api/ai-plugin/route.ts
+++ b/src/app/api/ai-plugin/route.ts
@@ -82,6 +82,15 @@ This assistant follows these specifications with zero deviation to ensure secure
             { $ref: "#/components/parameters/buyToken" },
             { $ref: "#/components/parameters/receiver" },
             {
+              name: "validFor",
+              in: "query",
+              schema: {
+                type: "number",
+              },
+              description:
+                "Number of seconds (from now) that the order should be valid for. Max 3 hours (10800).",
+            },
+            {
               name: "slippageBps",
               in: "query",
               schema: {

--- a/src/app/api/tools/quote/logic.ts
+++ b/src/app/api/tools/quote/logic.ts
@@ -8,6 +8,7 @@ import { getAddress, type Address } from "viem";
 import { isNativeAsset } from "zerion-sdk";
 
 import { COW_SUPPORTED_CHAINS, getAlchemyKey } from "@/src/app/config";
+import { withCowErrorHandling } from "@/src/lib/error";
 import { basicParseQuote, preliminarySteps } from "@/src/lib/protocol/quote";
 import { applySlippage, setPresignatureTx } from "@/src/lib/protocol/util";
 import { getClient } from "@/src/lib/rpc";
@@ -54,7 +55,9 @@ export async function handleQuoteRequest({
   const orderBookApi = new OrderBookApi({ chainId });
 
   // WARNING: Do not unpack this result as { quote, ...}. It causes confusion due to modifications.
-  const result = await orderBookApi.getQuote(quoteRequest);
+  const result = await withCowErrorHandling(
+    orderBookApi.getQuote(quoteRequest),
+  );
 
   console.log("POST Response for quote:", result.quote);
   if (result.from === undefined) {

--- a/src/lib/protocol/quote.ts
+++ b/src/lib/protocol/quote.ts
@@ -29,6 +29,7 @@ export async function basicParseQuote(
     amount,
     orderKind,
     evmAddress: sender,
+    validFor,
     receiver,
     slippageBps,
   } = requestBody;
@@ -59,6 +60,7 @@ export async function basicParseQuote(
       receiver: receiver ?? sender,
       from: sender,
       signingScheme: senderIsEoa ? SigningScheme.EIP712 : SigningScheme.PRESIGN,
+      validFor,
     },
     tokenData: {
       buy: buyTokenData,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,7 @@ export type QuoteRequestBody = {
   evmAddress: `0x${string}`;
   receiver: string;
   slippageBps?: number;
+  validFor?: number;
 };
 export interface ParsedQuoteRequest {
   quoteRequest: OrderQuoteRequest;

--- a/tests/quote.spec.ts
+++ b/tests/quote.spec.ts
@@ -2,8 +2,8 @@ import { handleQuoteRequest } from "@/src/app/api/tools/quote/logic";
 import { withRedactedErrorHandling } from "@/src/lib/error";
 import { ParsedQuoteRequest } from "@/src/lib/types";
 import { OrderQuoteRequest } from "@cowprotocol/cow-sdk";
-
-describe.skip("Quote Route Logic", () => {
+const MAX_VALID_FROM = 10800; // 3 hours
+describe("Quote Route Logic", () => {
   it("should transform parsedQuoteRequest into Full Quote", async () => {
     const quoteRequest = {
       sellToken: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", // ETH
@@ -13,7 +13,9 @@ describe.skip("Quote Route Logic", () => {
       receiver: "0xB00b4C1e371DEe4F6F32072641430656D3F7c064",
       from: "0xB00b4C1e371DEe4F6F32072641430656D3F7c064",
       signingScheme: "eip712",
+      validFor: MAX_VALID_FROM + 1,
     } as OrderQuoteRequest;
+
     const tokenData = {
       sell: {
         address: quoteRequest.sellToken,
@@ -34,8 +36,10 @@ describe.skip("Quote Route Logic", () => {
       tokenData,
       slippageBps: 100,
     } as ParsedQuoteRequest;
+    // const quote = await handleQuoteRequest(input);
+    // console.log(JSON.stringify(quote.meta.quote, null, 2));
     await expect(
       withRedactedErrorHandling(handleQuoteRequest(input)),
-    ).rejects.toThrow();
+    ).rejects.toThrow("ExcessiveValidTo: validTo is too far into the future");
   }, 10000);
 });


### PR DESCRIPTION
Closes #106 

We opted to use `validFor` instead of `validTo` to align with the cow frontend:

<img width="316" height="343" alt="image" src="https://github.com/user-attachments/assets/deef5421-cc4c-44ba-ad16-4b96f3be2826" />

This is an optional field with default of 30 minutes (max of 3 hours).