### PR TITLE
Always 200

### DIFF
--- a/src/app/api/tools/quote/route.ts
+++ b/src/app/api/tools/quote/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } catch (error: unknown) {
     return NextResponse.json(
       { message: (error as Error).message },
-      { status: 500 },
+      { status: 200 },
     );
   }
 }


### PR DESCRIPTION
We have found that the LLM/Chat does not interpret HTTP error codes very well. Instead now, we pack error messaging into the 200 response. 

Now, the chat can relay the CoWApiErrors back to the user meaningfully.

# Testing

Try out the following prompt:

> Swap 0.01 USDC for WETH on ethereum mainnet

Will tell you that: 

> The sell amount is too low to cover the transaction fee on the Ethereum mainnet. You may need to increase the amount you are selling to proceed with the swap.

See ChatId `3k9VgEZE6xHJrqXH`